### PR TITLE
[GOVCMSD10-448] Create a new Docker image named govcmstesting/php:8.2-apache for testing in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This repository contains Docker images designed for testing and development with
 
 ### PHP-Apache Images
 
+- `govcmstesting/php:8.2-apache`: PHP 8.2 with Apache web server.
 - `govcmstesting/php:8.1-apache`: PHP 8.1 with Apache web server.
 - `govcmstesting/php:7.4-apache`: PHP 7.4 with Apache web server.
 
 ### PHP-CLI Images
 
+- `govcmstesting/php:8.2-cli`: PHP 8.2 for command-line operations.
 - `govcmstesting/php:8.1-cli`: PHP 8.1 for command-line operations.
 - `govcmstesting/php:7.4-cli`: PHP 7.4 for command-line operations.
 
@@ -18,36 +20,36 @@ This repository contains Docker images designed for testing and development with
 
 ### Building Images
 
-You can build these images using the provided Dockerfiles. For example, to build the PHP-Apache image for PHP 8.1, use the following command:
+You can build these images using the provided Dockerfiles. For example, to build the PHP-Apache image for PHP 8.2, use the following command:
 
 ```bash
-docker build --tag govcmstesting/php:8.1-apache .
+docker build --tag govcmstesting/php:8.2-apache .
 ```
 
 ### Releasing Images
 
-To release these images, you can use Docker Buildx, which allows you to build and push images for multiple platforms. For instance, to release the PHP-Apache image for PHP 8.1 for various platforms, use the following command:
+To release these images, you can use Docker Buildx, which allows you to build and push images for multiple platforms. For instance, to release the PHP-Apache image for PHP 8.2 for various platforms, use the following command:
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 --tag govcmstesting/php:8.1-apache --push .
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 --tag govcmstesting/php:8.2-apache --push .
 ```
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 --tag govcmstesting/php:8.1-cli --push .
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 --tag govcmstesting/php:8.2-cli --push .
 ```
 
 Make sure to configure Docker Buildx appropriately to work with multiple platforms.
 
 ### Pulling Images
 
-You can pull these images from a container registry using docker pull. For instance, to pull the PHP 7.4 Apache image, use the following command:
+You can pull these images from a container registry using docker pull. For instance, to pull the PHP 8.2 Apache image, use the following command:
 
 ```bash
-docker pull govcmstesting/php:8.1-apache
+docker pull govcmstesting/php:8.2-apache
 ```
 
 ```bash
-docker pull govcmstesting/php:8.1-cli
+docker pull govcmstesting/php:8.2-cli
 ```
 
 ## License

--- a/images/php/8.2-apache/Dockerfile
+++ b/images/php/8.2-apache/Dockerfile
@@ -1,0 +1,71 @@
+# Use the PHP 8.2 with Apache base image
+FROM php:8.2-apache
+
+# Set the timezone to Australia/Sydney
+RUN ln -sf /usr/share/zoneinfo/Australia/Sydney /etc/localtime
+
+# Use UTF-8 locale
+RUN locale-gen C.UTF-8 || true
+ENV LANG=C.UTF-8
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Set non-interactive mode for APT
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90govcmsci \
+    && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90govcmsci
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-client git rsync unzip locales mariadb-client libicu-dev sqlite3 sudo
+
+# Install PHP extensions
+RUN apt-get install -y --no-install-recommends \
+    libfreetype6-dev libjpeg-dev libpng-dev libpq-dev libzip-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg=/usr \
+    && docker-php-ext-install -j "$(nproc)" gd opcache pdo_mysql zip intl
+
+# Install Node.js and Yarn
+RUN apt-get install -y apt-transport-https && \
+    curl -sL https://deb.nodesource.com/setup_18.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install -y nodejs && \
+    npm install -g npm@latest && \
+    npm install -g yarn@latest
+
+# Set environment variables
+ENV TERM xterm
+ENV npm_config_loglevel warn
+ENV npm_config_unsafe_perm true
+
+# Install Cypress dependencies
+RUN apt-get install -y \
+    libgtk2.0-0 libgtk-3-0 libgbm-dev \
+    libnotify-dev \
+    libgconf-2-4 libnss3 libxss1 \
+    libasound2 libxtst6 xauth xvfb
+
+# Clean up the installation files
+RUN apt-get autoclean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
+# Configure PHP settings
+RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# Install Dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" && \
+    curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL && \
+    tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz && \
+    rm -rf /tmp/dockerize-linux-amd64.tar.gz && \
+    dockerize --version
+
+# Copy Composer binary and set memory limit
+COPY --from=composer /usr/bin/composer /usr/local/bin/
+ENV COMPOSER_MEMORY_LIMIT=-1

--- a/images/php/8.2-cli/Dockerfile
+++ b/images/php/8.2-cli/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.2-cli-alpine
+
+RUN apk add --no-cache git patch rsync unzip freetype-dev libjpeg-turbo-dev libpng-dev libzip-dev zip \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg=/usr \
+    && docker-php-ext-configure zip \
+    && docker-php-ext-install -j "$(nproc)" gd zip
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/
+ENV COMPOSER_MEMORY_LIMIT=-1
+ENV COMPOSER_ALLOW_SUPERUSER=1


### PR DESCRIPTION
Ref: https://github.com/govcms-tests/docker-ci/tree/main

To test PHP 8.2 in CI, we need to make a new Docker image called govcmstesting/php:8.2-apache.